### PR TITLE
bookmarkのcrate処理をuseCase層に委譲

### DIFF
--- a/src/app/Bookmark/UseCase/CreateBookmarkUseCase.php
+++ b/src/app/Bookmark/UseCase/CreateBookmarkUseCase.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Bookmark\UseCase;
+
+use App\Models\Bookmark;
+use Dusterio\LinkPreview\Client;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Validation\ValidationException;
+
+final class CreateBookmarkUseCase
+{
+    /**
+     * ブックマーク作成処理
+     *
+     * 未ログインの場合、処理を続行するわけにはいかないのでログインページへリダイレクト
+     *
+     * 投稿内容のURL、コメント、カテゴリーは不正な値が来ないようにバリデーション
+     *
+     * ブックマークするページのtitle, description, サムネイル画像を専用のライブラリを使って取得し、
+     * 一緒にデータベースに保存する※ユーザーに入力してもらうのは手間なので
+     * URLが存在しないなどの理由で失敗したらバリデーションエラー扱いにする
+     *
+     * @param string $url
+     * @param int $category
+     * @param string $comment
+     * @throws ValidationException
+     */
+    public function handle(string $url, int $category, string $comment)
+    {
+        // 下記のサービスでも同様のことが実現できる
+        // @see https://www.linkpreview.net/
+        $previewClient = new Client($url);
+        try {
+            $preview = $previewClient->getPreview('general')->toArray();
+
+            $model = new Bookmark();
+            $model->url = $url;
+            $model->category_id = $category;
+            $model->user_id = Auth::id();
+            $model->comment = $comment;
+            $model->page_title = $preview['title'];
+            $model->page_description = $preview['description'];
+            $model->page_thumbnail_url = $preview['cover'];
+            $model->save();
+        } catch (\Exception $e) {
+            Log::error($e->getMessage());
+            throw ValidationException::withMessages([
+                'url' => 'URLが存在しない等の理由で読み込めませんでした。変更して再度投稿してください'
+            ]);
+        }
+    }
+}

--- a/src/app/Http/Controllers/Bookmarks/BookmarkController.php
+++ b/src/app/Http/Controllers/Bookmarks/BookmarkController.php
@@ -3,6 +3,7 @@
 
 namespace App\Http\Controllers\Bookmarks;
 
+use App\Bookmark\UseCase\CreateBookmarkUseCase;
 use App\Bookmark\UseCase\ShowBookmarkListPageUseCase;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\CreateBookmarkRequest;
@@ -125,27 +126,8 @@ class BookmarkController extends Controller
      */
     public function create(CreateBookmarkRequest $request)
     {
-        // 下記のサービスでも同様のことが実現できる
-        // @see https://www.linkpreview.net/
-        $previewClient = new Client($request->url);
-        try {
-            $preview = $previewClient->getPreview('general')->toArray();
-
-            $model = new Bookmark();
-            $model->url = $request->url;
-            $model->category_id = $request->category;
-            $model->user_id = Auth::id();
-            $model->comment = $request->comment;
-            $model->page_title = $preview['title'];
-            $model->page_description = $preview['description'];
-            $model->page_thumbnail_url = $preview['cover'];
-            $model->save();
-        } catch (Exception $e) {
-            Log::error($e->getMessage());
-            throw ValidationException::withMessages([
-                'url' => 'URLが存在しない等の理由で読み込めませんでした。変更して再度投稿してください'
-            ]);
-        }
+        $useCase = new CreateBookmarkUseCase();
+        $useCase->handle($request->url, $request->category, $request->comment);
 
         // 暫定的に成功時は一覧ページへ
         return redirect('/bookmarks', 302);


### PR DESCRIPTION
bookmarkコントローラーのリファクタリング
コントローラー内のcreateメソッドが肥大化していたので、createのロジックをUseCase層に委譲してファットコントローラーの改善を図りました